### PR TITLE
feat: 支持崩坏3、绝区零等无专属COS板块的游戏搜索

### DIFF
--- a/mihoyo_cos.py
+++ b/mihoyo_cos.py
@@ -54,6 +54,14 @@ def get_gids(forum: str) -> GameType:
     return forum2gids[forum]
 
 
+def has_cos_forum(game: int) -> bool:
+    """
+    根据游戏id区分是否具有cos分区，用于使用不同的搜索策略
+    """
+    has_cos = [GameType.Genshin.value, GameType.DBY.value, GameType.StarRail.value]
+    return game in has_cos
+
+
 class Search:
     """
     搜索帖子
@@ -113,12 +121,15 @@ class Search:
         return [image for post in posts for image in post["post"]["images"]]
 
     def _get_params(self, page_size: int = 10) -> dict:
-        return {
+        params = {
             "gids": self.gids,
             "size": page_size,
-            "keyword": self.keyword,
-            "forum_id": self.forum_id,
+            # 如果没有专属cos区，加上"cos"在总分区进行搜索
+            "keyword": self.keyword if has_cos_forum(self.gids) else self.keyword + 'cos',
         }
+        if has_cos_forum(self.gids):
+            params["forum_id"] = self.forum_id
+        return params
 
     async def async_get_urls(self, page_size: int = 10) -> list:
         params = self._get_params(page_size)
@@ -176,4 +187,12 @@ FORUM_TYPE_MAP = {
     "大别野": ForumType.DBYCOS,
     "星穹铁道": ForumType.StarRailCos,
     "崩铁": ForumType.StarRailCos,
+    "崩坏3": ForumType.Honkai3rdPic,
+    "崩坏三": ForumType.Honkai3rdPic,
+    "崩三": ForumType.Honkai3rdPic,
+    "绝区零": ForumType.ZZZ,
+    "zzz": ForumType.ZZZ,
+    "ZZZ": ForumType.ZZZ,
+    "崩坏2": ForumType.Honkai2Pic,
+    "崩二": ForumType.Honkai2Pic
 }


### PR DESCRIPTION
- 新增 `has_cos_forum` 方法，用于判断游戏是否具有专属 COS 板块。
- 修改 API 请求参数构建逻辑：对于无专属 COS 板块的游戏，动态移除 `forum_id` 以触发全区搜索，并在搜索关键词后自动追加 " cos" 以保证搜索结果的准确性。
- 扩充 `FORUM_TYPE_MAP` 字典，新增崩坏3、绝区零、崩坏学园2及其常见别名的映射。